### PR TITLE
feat(prometheus): Implement Local Span metrics

### DIFF
--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -2,6 +2,7 @@ import base64
 import ipaddress
 
 from typing import Any
+from typing import Optional
 from typing import Type
 from typing import Union
 
@@ -107,10 +108,13 @@ class BaseplateSession:
 
     """
 
-    def __init__(self, adapter: HTTPAdapter, name: str, span: Span) -> None:
+    def __init__(
+        self, adapter: HTTPAdapter, name: str, span: Span, client_name: Optional[str] = None
+    ) -> None:
         self.adapter = adapter
         self.name = name
         self.span = span
+        self.client_name = client_name
 
     def delete(self, url: str, **kwargs: Any) -> Response:
         """Send a DELETE request.
@@ -200,10 +204,13 @@ class BaseplateSession:
 
     def send(self, request: PreparedRequest, **kwargs: Any) -> Response:
         """Send a :py:class:`~requests.PreparedRequest`."""
-        with self.span.make_child(f"{self.name}.request") as span:
-            span.set_tag("http.method", request.method)
-            span.set_tag("http.url", request.url)
-
+        tags = {
+            "protocol": "http",
+            "http.method": request.method,
+            "http.url": request.url,
+            "http.slug": self.client_name if self.client_name is not None else self.name,
+        }
+        with self.span.make_child(f"{self.name}.request").with_tags(tags) as span:
             self._add_span_context(span, request)
 
             # we cannot re-use the same session every time because sessions re-use the same
@@ -216,7 +223,8 @@ class BaseplateSession:
             session.mount("https://", self.adapter)
             response = session.send(request, **kwargs)
 
-            span.set_tag("http.status_code", response.status_code)
+            http_status_code = response.status_code
+            span.set_tag("http.status_code", http_status_code)
         return response
 
 
@@ -257,15 +265,23 @@ class RequestsContextFactory(ContextFactory):
         :py:func:`http_adapter_from_config`.
     :param session_cls: The type for the actual session object to put on the
         request context.
+    :param client_name: Custom name to be emitted under the http_slug label
+        for prometheus metrics. Defaults back to session_cls.name if None
 
     """
 
-    def __init__(self, adapter: HTTPAdapter, session_cls: Type[BaseplateSession]) -> None:
+    def __init__(
+        self,
+        adapter: HTTPAdapter,
+        session_cls: Type[BaseplateSession],
+        client_name: Optional[str] = None,
+    ) -> None:
         self.adapter = adapter
         self.session_cls = session_cls
+        self.client_name = client_name
 
     def make_object_for_context(self, name: str, span: Span) -> BaseplateSession:
-        return self.session_cls(self.adapter, name, span)
+        return self.session_cls(self.adapter, name, span, client_name=self.client_name)
 
 
 class InternalRequestsClient(config.Parser):
@@ -288,9 +304,13 @@ class InternalRequestsClient(config.Parser):
 
     See :py:func:`http_adapter_from_config` for available configuration settings.
 
+    :param client_name: Custom name to be emitted under the http_slug label
+        for prometheus metrics. Defaults back to session_cls.name if None
+
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, client_name: Optional[str] = None, **kwargs: Any) -> None:
+        self.client_name = client_name
         self.kwargs = kwargs
 
         if "validator" in kwargs:
@@ -317,7 +337,9 @@ class InternalRequestsClient(config.Parser):
         adapter = http_adapter_from_config(
             raw_config, prefix=f"{key_path}.", validator=validator, **self.kwargs
         )
-        return RequestsContextFactory(adapter, session_cls=InternalBaseplateSession)
+        return RequestsContextFactory(
+            adapter, session_cls=InternalBaseplateSession, client_name=self.client_name
+        )
 
 
 class ExternalRequestsClient(config.Parser):
@@ -332,11 +354,17 @@ class ExternalRequestsClient(config.Parser):
 
     See :py:func:`http_adapter_from_config` for available configuration settings.
 
+    :param client_name: Custom name to be emitted under the http_slug label
+        for prometheus metrics. Defaults back to session_cls.name if None
+
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, client_name: Optional[str] = None, **kwargs: Any) -> None:
+        self.client_name = client_name
         self.kwargs = kwargs
 
     def parse(self, key_path: str, raw_config: config.RawConfig) -> RequestsContextFactory:
         adapter = http_adapter_from_config(raw_config, f"{key_path}.", **self.kwargs)
-        return RequestsContextFactory(adapter, session_cls=BaseplateSession)
+        return RequestsContextFactory(
+            adapter, session_cls=BaseplateSession, client_name=self.client_name
+        )

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -343,3 +343,60 @@ def getHTTPSuccessLabel(httpStatusCode: int) -> str:
     The HTTP success label is "true" if the status code is 2xx or 3xx, "false" otherwise.
     """
     return str(200 <= httpStatusCode < 400).lower()
+
+
+# local labels and metrics
+local_span_labels = [
+    "span",
+]
+# Latency histogram of local span
+# buckets are defined above (from 100µs to ~14.9s)
+local_span_latency_seconds = Histogram(
+    "local_span_latency_seconds",
+    "Latency histogram of local span",
+    local_span_labels,
+    buckets=default_latency_buckets,
+)
+
+# Counter counting total local spans started
+local_span_requests_total = Counter(
+    "local_span_requests_total",
+    "Total number of local spans started",
+    local_span_labels,
+)
+
+# Gauge showing current number of local spans
+local_span_active_requests = Gauge(
+    "local_span_active_requests",
+    "Number of active local spans",
+    local_span_labels,
+)
+
+
+class PrometheusLocalSpanMetrics:
+    def __init__(self) -> None:
+        pass
+
+    def latency_seconds_metric(self, tags: Dict) -> Histogram:
+        return local_span_latency_seconds.labels(
+            span=tags.get("span_name", ""),
+        )
+
+    def requests_total_metric(self, tags: Dict) -> Counter:
+        return local_span_requests_total.labels(
+            span=tags.get("span_name", ""),
+        )
+
+    def active_requests_metric(self, tags: Dict) -> Gauge:
+        return local_span_active_requests.labels(
+            span=tags.get("span_name", ""),
+        )
+
+    def get_latency_seconds_metric(self) -> Histogram:
+        return local_span_latency_seconds
+
+    def get_requests_total_metric(self) -> Counter:
+        return local_span_requests_total
+
+    def get_active_requests_metric(self) -> Gauge:
+        return local_span_active_requests

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -14,6 +14,7 @@ from baseplate import Span
 from baseplate import SpanObserver
 from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
+from baseplate.lib.prometheus_metrics import PrometheusLocalSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 from baseplate.thrift.ttypes import Error
@@ -56,9 +57,6 @@ class PrometheusServerSpanObserver(SpanObserver):
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
-
-    def get_prefix(self) -> str:
-        return f"{self.protocol}_server"
 
     def get_labels(self) -> Dict[str, str]:
         return self.tags
@@ -126,7 +124,7 @@ class PrometheusServerSpanObserver(SpanObserver):
     def on_child_span_created(self, span: Span) -> None:
         observer: Any = None
         if isinstance(span, LocalSpan):
-            observer = PrometheusLocalSpanObserver()
+            observer = PrometheusLocalSpanObserver(span.name)
         else:
             observer = PrometheusClientSpanObserver()
 
@@ -143,9 +141,6 @@ class PrometheusClientSpanObserver(SpanObserver):
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
-
-    def get_prefix(self) -> str:
-        return f"{self.protocol}_client"
 
     def get_labels(self) -> Dict[str, str]:
         return self.tags
@@ -206,7 +201,7 @@ class PrometheusClientSpanObserver(SpanObserver):
     def on_child_span_created(self, span: Span) -> None:
         observer: Optional[SpanObserver] = None
         if isinstance(span, LocalSpan):
-            observer = PrometheusLocalSpanObserver()
+            observer = PrometheusLocalSpanObserver(span.name)
         else:
             observer = PrometheusClientSpanObserver()
 
@@ -214,16 +209,42 @@ class PrometheusClientSpanObserver(SpanObserver):
 
 
 class PrometheusLocalSpanObserver(SpanObserver):
-    def __init__(self) -> None:
-        logger.debug("PrometheusLocalSpanObserver not implemented")
+    def __init__(self, span_name: Optional[str] = None) -> None:
+        self.tags: Dict[str, Any] = {"span_name": span_name if span_name is not None else ""}
+        self.start_time: Optional[int] = None
+        self.metrics: PrometheusLocalSpanMetrics = PrometheusLocalSpanMetrics()
 
-    # Proper implementation for PrometheusLocalSpanObserver will come in a future PR
-    # In the meantime, we need this logic in place to be able to emit http client metrics
-    # when running inside a local span
+    def on_set_tag(self, key: str, value: Any) -> None:
+        self.tags[key] = value
+
+    def get_labels(self) -> Dict[str, Any]:
+        return self.tags
+
+    def on_start(self) -> None:
+        self.start_time = time.perf_counter_ns()
+        self.metrics.active_requests_metric(self.tags).inc()
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        pass
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.tags["success"] = "true"
+        if exc_info is not None:
+            self.tags["exception_type"] = exc_info[1].__class__.__name__
+            self.tags["success"] = "false"
+
+        self.metrics.active_requests_metric(self.tags).dec()
+        self.metrics.requests_total_metric(self.tags).inc()
+        if self.start_time is not None:
+            elapsed_ns = time.perf_counter_ns() - self.start_time
+            self.metrics.latency_seconds_metric(self.tags).observe(
+                elapsed_ns / NANOSECONDS_PER_SECOND
+            )
+
     def on_child_span_created(self, span: Span) -> None:
         observer: Optional[SpanObserver] = None
         if isinstance(span, LocalSpan):
-            observer = PrometheusLocalSpanObserver()
+            observer = PrometheusLocalSpanObserver(span.name)
         else:
             observer = PrometheusClientSpanObserver()
 

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -58,6 +58,9 @@ class PrometheusServerSpanObserver(SpanObserver):
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
 
+    def get_prefix(self) -> str:
+        return f"{self.protocol}_server"
+
     def get_labels(self) -> Dict[str, str]:
         return self.tags
 
@@ -142,6 +145,9 @@ class PrometheusClientSpanObserver(SpanObserver):
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
 
+    def get_prefix(self) -> str:
+        return f"{self.protocol}_client"
+
     def get_labels(self) -> Dict[str, str]:
         return self.tags
 
@@ -216,6 +222,13 @@ class PrometheusLocalSpanObserver(SpanObserver):
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
+
+    def get_prefix(self) -> str:
+        return f"{self.protocol}_span"
+
+    @property
+    def protocol(self) -> str:
+        return "local"
 
     def get_labels(self) -> Dict[str, Any]:
         return self.tags

--- a/docs/api/baseplate/clients/requests.rst
+++ b/docs/api/baseplate/clients/requests.rst
@@ -31,6 +31,12 @@ declaration to your context configuration::
       }
    )
 
+Prometheus metrics include the `http_slug` label, by default the label
+value is set to the key name provided in the context. In the above code
+example the  `http_slug` labels will have the values `foo` and `bar`. If you
+would like to change the value of this label you can provide the
+`client_name` keyword argument when you create the requests client.
+
 configure it in your application's configuration file:
 
 .. code-block:: ini

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -1,9 +1,11 @@
 import importlib
+import logging
 
 import gevent
 import pytest
 import requests
 
+from prometheus_client import REGISTRY
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPNoContent
 
@@ -13,10 +15,13 @@ from baseplate.clients.requests import InternalRequestsClient
 from baseplate.frameworks.pyramid import BaseplateConfigurator
 from baseplate.frameworks.pyramid import StaticTrustHandler
 from baseplate.lib import config
+from baseplate.observers.prometheus import PrometheusBaseplateObserver
 from baseplate.server import make_listener
 from baseplate.server.wsgi import make_server
 
 from . import TestBaseplateObserver
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -65,12 +70,16 @@ def http_server(gevent_socket):
 
 
 @pytest.mark.parametrize("client_cls", [InternalRequestsClient, ExternalRequestsClient])
+@pytest.mark.parametrize("client_name", [None, "", "complex.client$name"])
 @pytest.mark.parametrize("method", ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "PUT", "POST"])
-def test_client_makes_client_span(client_cls, method, http_server):
+def test_client_makes_client_span(client_cls, client_name, method, http_server):
     baseplate = Baseplate(
         {"myclient.filter.ip_allowlist": "127.0.0.0/8", "myclient.filter.port_denylist": "0"}
     )
-    baseplate.configure_context({"myclient": client_cls()})
+    if client_name is None:
+        baseplate.configure_context({"myclient": client_cls()})
+    else:
+        baseplate.configure_context({"myclient": client_cls(client_name=client_name)})
 
     observer = TestBaseplateObserver()
     baseplate.register(observer)
@@ -92,6 +101,9 @@ def test_client_makes_client_span(client_cls, method, http_server):
     assert client_span_observer.tags["http.url"] == http_server.url
     assert client_span_observer.tags["http.method"] == method
     assert client_span_observer.tags["http.status_code"] == 204
+    assert client_span_observer.tags["http.slug"] == (
+        client_name if client_name is not None else "myclient"
+    )
 
 
 @pytest.mark.parametrize("client_cls", [InternalRequestsClient, ExternalRequestsClient])
@@ -158,3 +170,147 @@ def test_external_client_doesnt_send_headers(http_server):
         assert "X-Parent" not in http_server.requests[0].headers
         assert "X-Span" not in http_server.requests[0].headers
         assert "X-Edge-Request" not in http_server.requests[0].headers
+
+
+@pytest.mark.parametrize("client_cls", [InternalRequestsClient, ExternalRequestsClient])
+@pytest.mark.parametrize("client_name", [None, "", "complex.client$name"])
+@pytest.mark.parametrize("method", ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "PUT", "POST"])
+def test_prometheus_http_client_metrics(client_cls, client_name, method, http_server):
+    baseplate = Baseplate(
+        {"myclient.filter.ip_allowlist": "127.0.0.0/8", "myclient.filter.port_denylist": "0"}
+    )
+    logger.info("Created baseplate.")
+    if client_name is None:
+        baseplate.configure_context({"myclient": client_cls()})
+    else:
+        baseplate.configure_context({"myclient": client_cls(client_name=client_name)})
+    logger.info(
+        f"Configured baseplate context with requests client. [type={client_cls.__name__}, client_name={client_name}]"
+    )
+
+    observer = PrometheusBaseplateObserver()
+    logger.info(f"Created observer. [type={observer.__class__.__name__}]")
+    baseplate.register(observer)
+    logger.info("Registered observer with baseplate.")
+
+    # we need to clear metrics between test runs from the parametrize annotations
+    REGISTRY._names_to_collectors["http_client_requests_total"].clear()
+    REGISTRY._names_to_collectors["http_client_latency_seconds"].clear()
+    REGISTRY._names_to_collectors["http_client_active_requests"].clear()
+
+    with baseplate.server_context("test") as context:
+        logger.debug("Created server context.")
+        fn = getattr(context.myclient, method.lower())
+        logger.debug(f"Making HTTP call. [method={method}, endpoint={http_server.url}]")
+        response = fn(http_server.url)
+        logger.debug(f"Made HTTP call. [method={method}, endpoint={http_server.url}]")
+
+    assert response.status_code == 204
+
+    http_client_requests_total = REGISTRY._names_to_collectors[
+        "http_client_requests_total"
+    ].collect()
+    assert len(http_client_requests_total) == 1
+    assert len(http_client_requests_total[0].samples) == 2  # _total and _created
+    http_client_requests_total_total = http_client_requests_total[0].samples[0]
+    assert http_client_requests_total_total.name == "http_client_requests_total"
+    assert http_client_requests_total_total.labels.get("http_method") == method
+    assert http_client_requests_total_total.labels.get("http_response_code") == "204"
+    assert http_client_requests_total_total.labels.get("http_success") == "true"
+    assert http_client_requests_total_total.labels.get("http_slug") == (
+        client_name if client_name is not None else "myclient"
+    )
+    assert http_client_requests_total_total.value == 1
+
+    http_client_latency_seconds = REGISTRY._names_to_collectors[
+        "http_client_latency_seconds"
+    ].collect()
+    assert len(http_client_latency_seconds) == 1
+    assert (
+        len(http_client_latency_seconds[0].samples) == 18
+    )  # 15 time buckets (inc. inf), _count, _sum and _created
+    http_client_latency_seconds_inf = http_client_latency_seconds[0].samples[14]
+    assert http_client_latency_seconds_inf.labels.get("le") == "+Inf"
+    assert http_client_latency_seconds_inf.labels.get("http_method") == method
+    assert http_client_latency_seconds_inf.labels.get("http_success") == "true"
+    assert http_client_latency_seconds_inf.labels.get("http_slug") == (
+        client_name if client_name is not None else "myclient"
+    )
+    assert http_client_latency_seconds_inf.value == 1
+    http_client_latency_seconds_count = http_client_latency_seconds[0].samples[
+        15
+    ]  # no need to test the tags again since they all in the same sample
+    assert http_client_latency_seconds_count.value == 1
+
+    http_client_active_requests = REGISTRY._names_to_collectors[
+        "http_client_active_requests"
+    ].collect()
+    assert len(http_client_active_requests) == 1
+    assert len(http_client_active_requests[0].samples) == 1
+    http_client_active_requests_samples = http_client_active_requests[0].samples[0]
+    assert http_client_active_requests_samples.labels.get("http_method") == method
+    assert http_client_active_requests_samples.labels.get("http_slug") == (
+        client_name if client_name is not None else "myclient"
+    )
+    assert http_client_active_requests_samples.value == 0
+
+
+@pytest.mark.parametrize("method", ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "PUT", "POST"])
+def test_prometheus_http_client_metrics_inside_local_span(method, http_server):
+    baseplate = Baseplate(
+        {"myclient.filter.ip_allowlist": "127.0.0.0/8", "myclient.filter.port_denylist": "0"}
+    )
+    logger.info("Created baseplate.")
+    baseplate.configure_context({"myclient": InternalRequestsClient()})
+
+    observer = PrometheusBaseplateObserver()
+    logger.info(f"Created observer. [type={observer.__class__.__name__}]")
+    baseplate.register(observer)
+    logger.info("Registered observer with baseplate.")
+
+    # we need to clear metrics between test runs from the parametrize annotations
+    REGISTRY._names_to_collectors["http_client_requests_total"].clear()
+    REGISTRY._names_to_collectors["http_client_latency_seconds"].clear()
+    REGISTRY._names_to_collectors["http_client_active_requests"].clear()
+
+    with baseplate.server_context("test") as context:
+        with context.span.make_child("local", local=True) as span:
+            logger.debug("Created local context.")
+            fn = getattr(span.context.myclient, method.lower())
+            logger.debug(f"Making HTTP call. [method={method}, endpoint={http_server.url}]")
+            response = fn(http_server.url)
+            logger.debug(f"Made HTTP call. [method={method}, endpoint={http_server.url}]")
+
+    assert response.status_code == 204
+
+    # Only making quick checks here, since this is meant to ensure that we do record metrics inside
+    # a local span at all. Whether tags etc. are valid are tested in a previous test:
+    # test_prometheus_http_client_metrics
+    http_client_requests_total = REGISTRY._names_to_collectors[
+        "http_client_requests_total"
+    ].collect()
+    assert len(http_client_requests_total) == 1
+    assert len(http_client_requests_total[0].samples) == 2  # _total and _created
+    http_client_requests_total_total = http_client_requests_total[0].samples[0]
+    assert http_client_requests_total_total.value == 1
+
+    http_client_latency_seconds = REGISTRY._names_to_collectors[
+        "http_client_latency_seconds"
+    ].collect()
+    assert len(http_client_latency_seconds) == 1
+    assert (
+        len(http_client_latency_seconds[0].samples) == 18
+    )  # 15 time buckets (inc. inf), _count, _sum and _created
+    http_client_latency_seconds_inf = http_client_latency_seconds[0].samples[14]
+    assert http_client_latency_seconds_inf.labels.get("le") == "+Inf"
+    assert http_client_latency_seconds_inf.value == 1
+    http_client_latency_seconds_count = http_client_latency_seconds[0].samples[15]
+    assert http_client_latency_seconds_count.value == 1
+
+    http_client_active_requests = REGISTRY._names_to_collectors[
+        "http_client_active_requests"
+    ].collect()
+    assert len(http_client_active_requests) == 1
+    assert len(http_client_active_requests[0].samples) == 1
+    http_client_active_requests_samples = http_client_active_requests[0].samples[0]
+    assert http_client_active_requests_samples.value == 0

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -70,6 +70,28 @@ class TestException(Exception):
                 "active_labels": {"http_method": "", "http_endpoint": ""},
             },
         ),
+        (
+            "http",
+            "client",
+            PrometheusClientSpanObserver,
+            {
+                "latency_labels": {
+                    "http_method": "",
+                    "http_success": "false",
+                    "http_slug": "",
+                },
+                "requests_labels": {
+                    "http_method": "",
+                    "http_success": "false",
+                    "http_response_code": "",
+                    "http_slug": "",
+                },
+                "active_labels": {
+                    "http_method": "",
+                    "http_slug": "",
+                },
+            },
+        ),
     ),
 )
 def test_observer_metrics(protocol, client_or_server, observer_cls, labels):

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -128,6 +128,8 @@ def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
 
     observer = observer_cls()
     observer.on_set_tag("protocol", protocol)
+    assert observer.get_prefix() == f"{protocol}_{client_or_server}"
+
     observer.on_start()
     after_start = REGISTRY.get_sample_value(
         f"{protocol}_{client_or_server}_latency_seconds_count", labels.get("latency_labels", "")

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -10,6 +10,7 @@ from baseplate import ServerSpan
 from baseplate.lib.prometheus_metrics import getHTTPSuccessLabel
 from baseplate.observers.prometheus import PrometheusBaseplateObserver
 from baseplate.observers.prometheus import PrometheusClientSpanObserver
+from baseplate.observers.prometheus import PrometheusLocalSpanObserver
 from baseplate.observers.prometheus import PrometheusServerSpanObserver
 
 
@@ -92,6 +93,22 @@ class TestException(Exception):
                 },
             },
         ),
+        (
+            "local",
+            "span",
+            PrometheusLocalSpanObserver,
+            {
+                "latency_labels": {
+                    "span": "",
+                },
+                "requests_labels": {
+                    "span": "",
+                },
+                "active_labels": {
+                    "span": "",
+                },
+            },
+        ),
     ),
 )
 def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
@@ -111,8 +128,6 @@ def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
 
     observer = observer_cls()
     observer.on_set_tag("protocol", protocol)
-    assert observer.get_prefix() == f"{protocol}_{client_or_server}"
-
     observer.on_start()
     after_start = REGISTRY.get_sample_value(
         f"{protocol}_{client_or_server}_latency_seconds_count", labels.get("latency_labels", "")


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
Emit prometheus metrics for local spans. Namely:
- latency
- total number of spans created
- current number of active spans
The only label associated with these metrics is the name of the span.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Testing this should be as simple as adding the following snippet to a working baseplate.py app:
```
    with baseplate.server_context("test") as context:
        with context.span.make_child('ipinfo_calls', local=True, component_name='ipinfo.io'):
            context.external.get('https://ipinfo.io/ip')
            context.external.get('https://ipinfo.io/json')
            context.external.get('https://ipinfo.io/error')
```
Which will result in metrics looking like:
```
# HELP local_span_active Multiprocess metric
# TYPE local_span_active gauge
local_span_active{pid="56142",span="ipinfo_calls"} 0.0
# HELP local_span_latency_seconds Multiprocess metric
# TYPE local_span_latency_seconds histogram
local_span_latency_seconds_sum{span="ipinfo_calls"} 0.138987024
local_span_latency_seconds_bucket{le="0.0001",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.00025",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.000625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.0015625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.00390625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.009765625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.0244140625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.06103515625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.152587890625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="0.3814697265625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="0.95367431640625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="2.384185791015625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="5.9604644775390625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="14.901161193847656",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="+Inf",span="ipinfo_calls"} 1.0
local_span_latency_seconds_count{span="ipinfo_calls"} 1.0
# HELP local_span_total Multiprocess metric
# TYPE local_span_total counter
local_span_total{span="ipinfo_calls"} 1.0
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
